### PR TITLE
Change #replace call from innerHTML to outerHTML

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ export default class extends Controller {
     event.preventDefault()
 
     const [, , xhr] = event.detail
-    this.element.innerHTML = xhr.response
+    this.element.outerHTML = xhr.response
   }
 
   append (event) {


### PR DESCRIPTION
This changes #replace to use [`Element.outerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML) instead of `Element.innerHTML`. `Element.innerHTML` only changes the elements children which is not helpfull for more complex behaviors. This can even be seen in the demo application. Clicking the 'Click me to replace 👈' link only replaces the inner contents of it, which means the xhr response remains inside an `<a>` tag.

`Element.outerHTML` changes the element itself including its descendants. I think this is a more preferable behavior. We are using the exact same setup in production and it's working for us with out any problems.